### PR TITLE
Fix PSRO examples for Leduc Hold'em

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ _build
 logs
 demos
 prof/
+
+# SMAC
+StarCraftII/

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ from malib.rollout import rollout_func
 
 
 env_description = {
-    "creator": PokerParallelEnv,
+    "creator": leduc_holdem.PokerParallelEnv,
     "config": {
         "scenario_configs": {"fixed_player": True},
         "env_id": "leduc_poker",
     },
 }
-env = PokerParallelEnv(**env_description["config"])
+env = leduc_holdem.PokerParallelEnv(**env_description["config"])
 possible_agents = env.possible_agents
 observation_spaces = env.observation_spaces
 action_spaces = env.action_spaces
@@ -71,13 +71,13 @@ run(
             "use_init_policy_pool": True,
         },
         "config": {
-            "batch_size": args.batch_size,
-            "update_interval": args.num_epoch,
+            "batch_size": 1024,
+            "update_interval": 8,
         },
     },
     algorithms={
-        args.algorithm: {
-            "name": args.algorithm,
+        "PSRO_PPO": {
+            "name": "PPO",
             "custom_config": {
                 "gamma": 1.0,
                 "eps_min": 0,
@@ -124,7 +124,7 @@ If you use MALib in your work, please cite the accompanying [paper](https://arxi
 
 ```bibtex
 @misc{zhou2021malib,
-      title={MALib: A Parallel Framework for Population-based Multi-agent Reinforcement Learning}, 
+      title={MALib: A Parallel Framework for Population-based Multi-agent Reinforcement Learning},
       author={Ming Zhou and Ziyu Wan and Hanjing Wang and Muning Wen and Runzhe Wu and Ying Wen and Yaodong Yang and Weinan Zhang and Jun Wang},
       year={2021},
       eprint={2106.07551},

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -9,7 +9,7 @@ If you have not installed MALib yet, please refer to :ref:`installation` before 
 PSRO Learning
 -------------
 
-**Policy Space Response Oracle (PSRO)** is a population-based MARL algorithm which cooperates game-theory and MARL algorithm to solve multi-agent tasks in the scope of meta-game. At each iteration, the algorithm will generate some policy combinations and executes independent learning for each agent. Such a nested learning process comprises rollout, training, evaluation in sequence, and works circularly until the algorithm finds the estimated Nash Equilibrium. 
+**Policy Space Response Oracle (PSRO)** is a population-based MARL algorithm which cooperates game-theory and MARL algorithm to solve multi-agent tasks in the scope of meta-game. At each iteration, the algorithm will generate some policy combinations and executes independent learning for each agent. Such a nested learning process comprises rollout, training, evaluation in sequence, and works circularly until the algorithm finds the estimated Nash Equilibrium.
 
 .. note:: If you want to use alpha\-rank to estimate the equilibrium, you need to install open\-spiel before that. Follow the :ref:`installation` to get more details.
 
@@ -22,9 +22,9 @@ The first thing to start your training task is to determine the environment for 
 
     from malib.envs.poker import poker_aec_env as leduc_holdem
 
-    env = leduc_holdem.env(scenario_configs={"fixed_player": True}, env_id="leduc_poker")
+    env = leduc_holdem.PokerParallelEnv(scenario_configs={"fixed_player": True}, env_id="leduc_poker")
     env_description = {
-        "creator": leduc_holdem.env,
+        "creator": leduc_holdem.PokerParallelEnv,
         "config": {
             "scenario_configs": {"fixed_player": True},
             "env_id": "leduc_poker",

--- a/malib/evaluator/utils/payoff_table.py
+++ b/malib/evaluator/utils/payoff_table.py
@@ -17,7 +17,7 @@ class PayoffTable:
         # record policy idx
         self._policy_idx = {agent: {} for agent in self.agents}
         self.table = np.zeros([0] * len(self.agents), dtype=np.float32)
-        self.simulation_flag = np.zeros([0] * len(self.agents), dtype=np.bool)
+        self.simulation_flag = np.zeros([0] * len(self.agents), dtype=np.bool8)
 
     def __getitem__(self, key: Dict[str, Sequence[PolicyID]]) -> np.ndarray:
         """Return a sub matrix"""

--- a/malib/runner.py
+++ b/malib/runner.py
@@ -43,7 +43,7 @@ def run(**kwargs):
 
         try:
             start_ray_info = ray.init(address="auto")
-        except ConnectionError:
+        except OSError:
             Logger.warning(
                 "No active cluster deteced, will create a local ray instance."
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ numpy~=1.19.5
 torch~=1.8.1
 tensorboardX~=2.1
 tensorboard
+dm_tree
 readerwriterlock
 nashpy==0.0.21
 pymongo

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "torch",
         "tensorboardX",
         "tensorboard",
+        "dm_tree",
         "readerwriterlock",
         "nashpy==0.0.21",
         "pymongo",


### PR DESCRIPTION
Hi, thanks for creating such an amazing framework for MARL.

I'm trying to run the example code shown in [README.md](https://github.com/sjtu-marl/malib#quick-start) and/or <https://malib.io>. I found some bugs that trouble beginners with this repo. Such as:

- module not found `tree`: missing dependency `dm_tree`

- not self-contained examples: name errors for `PokerParallelEnv` and `args.xxx`.

- narrowed exception handler: `ray.init(address="auto")` (which calls `socket.gethostbyname()`) now raises `socket.gaierror`. We should catch it with `OSError`.

- `leduc_holdem.env` is not capable with `malib.envs.vector_env.VectorEnv`

In `VectorEnv.reset`:

https://github.com/sjtu-marl/malib/blob/5be07ac00761a34fb095adb2b3018a798ceea256/malib/envs/vector_env.py#L191-L193

`env.reset()` is called with arguments. However, `PockerEnv.reset` and wrappers provided by `pettingzoo` do not accept any arguments.

https://github.com/sjtu-marl/malib/blob/5be07ac00761a34fb095adb2b3018a798ceea256/malib/envs/poker/poker_aec_env.py#L131-L135

https://github.com/sjtu-marl/malib/blob/5be07ac00761a34fb095adb2b3018a798ceea256/malib/envs/poker/poker_aec_env.py#L168-L178

https://github.com/Farama-Foundation/PettingZoo/blob/b839259e961798cfc23b6f82c6ba0898b55cda60/pettingzoo/utils/wrappers/base.py#L77-L85